### PR TITLE
Update social networking links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,9 +12,9 @@ owner:
   avatar:         bio-photo.png
   email:          jane@bed.coffee
   # Social networking links used in footer. Update and remove as you like.
-  twitter:        https://twitter.com/thejunglejane    
-  github:         https://github.com/thejunglejane    
-  instagram:      https://instagram.come/thejunglejane        
+  twitter:        thejunglejane    
+  github:         thejunglejane    
+  instagram:      thejunglejane        
   # For Google Authorship https://plus.google.com/authorship
   google_plus:    
 


### PR DESCRIPTION
In the [footer file](https://github.com/thejunglejane/bed.coffee/blob/gh-pages/_includes/footer.html), the domains are already prefixed.  Just need the handle here.

Right now the links on the live page look like `http://twitter.com/https://twitter.com/thejunglejane` :(
